### PR TITLE
Don't override system library already provided by Java

### DIFF
--- a/athena-343.lua
+++ b/athena-343.lua
@@ -84,16 +84,6 @@ _G.loadfile = nil
 _G.dofile = nil
 _G.module = nil
 
-system = {
-  _m = {},
-  getItem = function(key)
-    return system._m[key]
-  end,
-  setItem = function(key, value)
-    system._m[key] = value
-  end
-}
-
 abi = {
   register = function (funcname, ...)
   end

--- a/src/main/lua/mockup.lua
+++ b/src/main/lua/mockup.lua
@@ -11,16 +11,6 @@ _G.loadfile = nil
 _G.dofile = nil
 _G.module = nil
 
-system = {
-  _m = {},
-  getItem = function(key)
-    return system._m[key]
-  end,
-  setItem = function(key, value)
-    system._m[key] = value
-  end
-}
-
 abi = {
   register = function (funcname, ...)
   end


### PR DESCRIPTION
`Athena.java` and `AergoMock.java` already implement `getItem` and `setItem` of the system library.